### PR TITLE
Fix README repository link

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,8 +12,8 @@ A simple Python tool to track token transactions on BSC (Binance Smart Chain) fo
 
 ```bash
 # Clone repository
-git clone https://github.com/your-repo/binance-wallet-query.git
-cd binance-wallet-query
+git clone https://github.com/your-repo/bsc-wallet-tracker.git
+cd bsc-wallet-tracker
 
 # Create virtual environment
 python -m venv env


### PR DESCRIPTION
## Summary
- update repo URL and directory name in README setup section

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68410059db98832bbc0f2491c7edfc33