### PR TITLE
Update README with server info

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ pip install -r requirements.txt
 # Run the program
 python main.py
 ```
+Running `python main.py` launches a FastAPI server available at [http://localhost:8000](http://localhost:8000). The web UI can be accessed at this address.
+
 
 ## Configuration
 


### PR DESCRIPTION
## Summary
- clarify that running `python main.py` starts the FastAPI server
- note that the web UI is served on http://localhost:8000

## Testing
- `python -m py_compile main.py`

------
https://chatgpt.com/codex/tasks/task_e_684100ee6d78832baa0b9edc31572b04