### PR TITLE
Add summarize_txs tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ python-dotenv
 fastapi
 uvicorn
 jinja2
+pytest

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -1,0 +1,103 @@
+import sys
+import os
+import types
+import pytest
+
+# Ensure the project root is on sys.path
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+
+# Stub external dependencies used in main.py so it can be imported without them
+sys.modules.setdefault('requests', types.ModuleType('requests'))
+
+dotenv_module = types.ModuleType('dotenv')
+dotenv_module.load_dotenv = lambda: None
+sys.modules.setdefault('dotenv', dotenv_module)
+
+# Minimal fastapi stubs
+fastapi_module = types.ModuleType('fastapi')
+class HTTPException(Exception):
+    def __init__(self, status_code=None, detail=None):
+        self.status_code = status_code
+        self.detail = detail
+class FastAPI:
+    def __init__(self, *args, **kwargs):
+        pass
+    def mount(self, *args, **kwargs):
+        pass
+    def get(self, *args, **kwargs):
+        def decorator(func):
+            return func
+        return decorator
+fastapi_module.FastAPI = FastAPI
+fastapi_module.HTTPException = HTTPException
+sys.modules.setdefault('fastapi', fastapi_module)
+
+staticfiles_module = types.ModuleType('fastapi.staticfiles')
+class StaticFiles:
+    def __init__(self, *args, **kwargs):
+        pass
+staticfiles_module.StaticFiles = StaticFiles
+sys.modules.setdefault('fastapi.staticfiles', staticfiles_module)
+
+templating_module = types.ModuleType('fastapi.templating')
+class Jinja2Templates:
+    def __init__(self, *args, **kwargs):
+        pass
+    def TemplateResponse(self, *args, **kwargs):
+        pass
+templating_module.Jinja2Templates = Jinja2Templates
+sys.modules.setdefault('fastapi.templating', templating_module)
+
+responses_module = types.ModuleType('fastapi.responses')
+class HTMLResponse:
+    pass
+responses_module.HTMLResponse = HTMLResponse
+sys.modules.setdefault('fastapi.responses', responses_module)
+
+requests_module = types.ModuleType('fastapi.requests')
+class Request:
+    pass
+requests_module.Request = Request
+sys.modules.setdefault('fastapi.requests', requests_module)
+
+pydantic_module = types.ModuleType('pydantic')
+class BaseModel:
+    pass
+pydantic_module.BaseModel = BaseModel
+sys.modules.setdefault('pydantic', pydantic_module)
+
+sys.modules.setdefault('uvicorn', types.ModuleType('uvicorn'))
+
+from main import summarize_txs
+
+
+def test_summarize_txs_empty():
+    summary = summarize_txs([])
+    assert dict(summary) == {}
+
+
+def test_summarize_txs_sample():
+    txs = [
+        {
+            "tokenSymbol": "AAA",
+            "tokenDecimal": "18",
+            "value": "1000000000000000000",
+        },
+        {
+            "tokenSymbol": "AAA",
+            "tokenDecimal": "18",
+            "value": "2000000000000000000",
+        },
+        {
+            "tokenSymbol": "BBB",
+            "tokenDecimal": "6",
+            "value": "1500000",
+        },
+    ]
+
+    summary = summarize_txs(txs)
+    expected = {
+        "AAA": {"count": 2, "total": 3.0},
+        "BBB": {"count": 1, "total": 1.5},
+    }
+    assert dict(summary) == expected


### PR DESCRIPTION
## Summary
- add pytest-based tests for `summarize_txs`
- ensure tests run without external deps by stubbing packages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68410209d068832b86d9528f0c696fe0