### PR TITLE
Add progress bar for BSC-USD volume

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -120,6 +120,31 @@ tr:hover {
   margin-bottom: 2rem;
 }
 
+.progress-section {
+  margin-bottom: 2rem;
+}
+
+.progress-bar {
+  width: 100%;
+  background-color: #e0e0e0;
+  border-radius: 8px;
+  overflow: hidden;
+  height: 20px;
+  margin-bottom: 0.5rem;
+}
+
+.progress-fill {
+  height: 100%;
+  background-color: #4caf50;
+  width: 0%;
+  transition: width 0.3s;
+}
+
+#progressText {
+  text-align: center;
+  margin-bottom: 1rem;
+}
+
 @media (max-width: 768px) {
   .container {
     padding: 1rem;

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -133,6 +133,13 @@ tr:hover {
   margin-bottom: 0.5rem;
 }
 
+.progress-labels {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.875rem;
+  margin-bottom: 0.5rem;
+}
+
 .progress-fill {
   height: 100%;
   background-color: #4caf50;

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,6 +35,10 @@
             <div class="progress-bar">
               <div id="progressFill" class="progress-fill"></div>
             </div>
+            <div class="progress-labels">
+              <span id="currentThresholdLabel"></span>
+              <span id="nextThresholdLabel"></span>
+            </div>
             <p id="progressText"></p>
           </div>
 
@@ -72,6 +76,8 @@
           const progressSection = document.getElementById("progressSection");
           const progressFill = document.getElementById("progressFill");
           const progressText = document.getElementById("progressText");
+          const currentThresholdLabel = document.getElementById("currentThresholdLabel");
+          const nextThresholdLabel = document.getElementById("nextThresholdLabel");
 
         // 顯示載入狀態
           loading.style.display = "block";
@@ -79,6 +85,8 @@
           results.style.display = "none";
           progressSection.style.display = "none";
           progressFill.style.width = "0%";
+          currentThresholdLabel.textContent = "";
+          nextThresholdLabel.textContent = "";
 
         try {
           const response = await fetch(`/transactions/${walletAddress}`);
@@ -119,6 +127,8 @@
               ((busd - currentThreshold) / (nextThreshold - currentThreshold)) * 100
             );
             progressFill.style.width = percent + "%";
+            currentThresholdLabel.textContent = currentThreshold.toLocaleString();
+            nextThresholdLabel.textContent = nextThreshold.toLocaleString();
             progressText.textContent = `目前 ${points} 分，累積 ${busd.toFixed(2)} BSC-USD，距離下一階段還差 ${remaining.toFixed(2)} BSC-USD`;
             progressSection.style.display = "block";
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -27,19 +27,27 @@
 
       <div id="error" class="error" style="display: none"></div>
 
-      <div id="results" style="display: none">
-        <h2>今日交易記錄</h2>
+        <div id="results" style="display: none">
+          <h2>今日交易記錄</h2>
 
-        <div class="summary-section">
-          <h3>交易彙總</h3>
-          <div id="summary"></div>
-        </div>
+          <div class="progress-section" id="progressSection" style="display: none">
+            <h3>BSC-USD 進度</h3>
+            <div class="progress-bar">
+              <div id="progressFill" class="progress-fill"></div>
+            </div>
+            <p id="progressText"></p>
+          </div>
 
-        <div class="transactions-section">
-          <h3>交易明細</h3>
-          <div id="transactions"></div>
+          <div class="summary-section">
+            <h3>交易彙總</h3>
+            <div id="summary"></div>
+          </div>
+
+          <div class="transactions-section">
+            <h3>交易明細</h3>
+            <div id="transactions"></div>
+          </div>
         </div>
-      </div>
     </div>
 
     <script>
@@ -55,17 +63,22 @@
       }
 
       // 查詢交易記錄的函數
-      async function fetchTransactions(walletAddress) {
-        const loading = document.getElementById("loading");
-        const error = document.getElementById("error");
-        const results = document.getElementById("results");
-        const summary = document.getElementById("summary");
-        const transactions = document.getElementById("transactions");
+        async function fetchTransactions(walletAddress) {
+          const loading = document.getElementById("loading");
+          const error = document.getElementById("error");
+          const results = document.getElementById("results");
+          const summary = document.getElementById("summary");
+          const transactions = document.getElementById("transactions");
+          const progressSection = document.getElementById("progressSection");
+          const progressFill = document.getElementById("progressFill");
+          const progressText = document.getElementById("progressText");
 
         // 顯示載入狀態
-        loading.style.display = "block";
-        error.style.display = "none";
-        results.style.display = "none";
+          loading.style.display = "block";
+          error.style.display = "none";
+          results.style.display = "none";
+          progressSection.style.display = "none";
+          progressFill.style.width = "0%";
 
         try {
           const response = await fetch(`/transactions/${walletAddress}`);
@@ -88,7 +101,21 @@
                   `;
           }
           summaryHtml += "</table>";
-          summary.innerHTML = summaryHtml;
+            summary.innerHTML = summaryHtml;
+
+            // 計算 BSC-USD 進度
+            const busd = data.summary["BSC-USD"] ? data.summary["BSC-USD"].total : 0;
+            let points = 0;
+            let nextThreshold = 2;
+            if (busd >= 2) {
+              points = Math.floor(Math.log2(busd));
+              nextThreshold = Math.pow(2, points + 1);
+            }
+            const remaining = Math.max(0, nextThreshold - busd);
+            const percent = Math.min(100, (busd / nextThreshold) * 100);
+            progressFill.style.width = percent + "%";
+            progressText.textContent = `目前 ${points} 分，累積 ${busd.toFixed(2)} BSC-USD，距離下一階段還差 ${remaining.toFixed(2)} BSC-USD`;
+            progressSection.style.display = "block";
 
           // 顯示交易明細
           let transactionsHtml =

--- a/templates/index.html
+++ b/templates/index.html
@@ -106,13 +106,18 @@
             // 計算 BSC-USD 進度
             const busd = data.summary["BSC-USD"] ? data.summary["BSC-USD"].total : 0;
             let points = 0;
+            let currentThreshold = 0;
             let nextThreshold = 2;
-            if (busd >= 2) {
-              points = Math.floor(Math.log2(busd));
-              nextThreshold = Math.pow(2, points + 1);
+            while (busd >= nextThreshold) {
+              points++;
+              currentThreshold = nextThreshold;
+              nextThreshold *= 2;
             }
             const remaining = Math.max(0, nextThreshold - busd);
-            const percent = Math.min(100, (busd / nextThreshold) * 100);
+            const percent = Math.min(
+              100,
+              ((busd - currentThreshold) / (nextThreshold - currentThreshold)) * 100
+            );
             progressFill.style.width = percent + "%";
             progressText.textContent = `目前 ${points} 分，累積 ${busd.toFixed(2)} BSC-USD，距離下一階段還差 ${remaining.toFixed(2)} BSC-USD`;
             progressSection.style.display = "block";


### PR DESCRIPTION
## Summary
- show progress section for BSC-USD trading volume
- calculate points from BSC-USD volume using doubling rule
- add styles for progress bar

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684108b71f90832b905975631012b631