### PR TITLE
Add grouped transaction formatting

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -181,27 +181,20 @@
 
           // 顯示交易明細
           let transactionsHtml =
-            "<table><tr><th>時間</th><th>代幣</th><th>數量</th><th>方向</th><th>交易地址</th></tr>";
+            "<table><tr><th>Hash</th><th>時間</th><th>兌換</th><th>Gas Fee</th></tr>";
           for (const tx of data.transactions) {
-            const timestamp = new Date(tx.timeStamp * 1000).toLocaleString(
+            const timestamp = new Date(tx.timestamp * 1000).toLocaleString(
               "zh-TW"
             );
-            const value = (
-              parseInt(tx.value) / Math.pow(10, parseInt(tx.tokenDecimal))
-            ).toFixed(4);
-            const direction =
-              tx.from.toLowerCase() === walletAddress.toLowerCase()
-                ? "發送"
-                : "接收";
-            const counterparty = direction === "發送" ? tx.to : tx.from;
+            const pair = `${tx.from.symbol} → ${tx.to.symbol}`;
+            const fee = Number(tx.gas).toFixed(8);
 
             transactionsHtml += `
                       <tr>
+                          <td>${tx.hash}</td>
                           <td>${timestamp}</td>
-                          <td>${tx.tokenSymbol}</td>
-                          <td>${value}</td>
-                          <td>${direction}</td>
-                          <td>${counterparty}</td>
+                          <td>${pair}</td>
+                          <td>${fee}</td>
                       </tr>
                   `;
           }

--- a/tests/test_summary.py
+++ b/tests/test_summary.py
@@ -68,7 +68,7 @@ sys.modules.setdefault('pydantic', pydantic_module)
 
 sys.modules.setdefault('uvicorn', types.ModuleType('uvicorn'))
 
-from main import summarize_txs
+from main import summarize_txs, transform_transactions
 
 
 def test_summarize_txs_empty():
@@ -101,3 +101,44 @@ def test_summarize_txs_sample():
         "BBB": {"count": 1, "total": 1.5},
     }
     assert dict(summary) == expected
+
+
+def test_transform_transactions_basic():
+    wallet = "0xWallet"
+    txs = [
+        {
+            "hash": "0xabc",
+            "timeStamp": "1",
+            "gasUsed": "21000",
+            "gasPrice": "10000000000",
+            "from": wallet,
+            "to": "0xrouter",
+            "contractAddress": "0xtokenA",
+            "tokenSymbol": "AAA",
+            "tokenDecimal": "18",
+            "value": "1000000000000000000",
+        },
+        {
+            "hash": "0xabc",
+            "timeStamp": "1",
+            "gasUsed": "21000",
+            "gasPrice": "10000000000",
+            "from": "0xrouter",
+            "to": wallet,
+            "contractAddress": "0xtokenB",
+            "tokenSymbol": "BBB",
+            "tokenDecimal": "6",
+            "value": "1500000",
+        },
+    ]
+
+    formatted = transform_transactions(txs, wallet)
+    assert len(formatted) == 1
+    tx = formatted[0]
+    assert tx["hash"] == "0xabc"
+    assert tx["timestamp"] == 1
+    assert tx["status"] == "success"
+    assert tx["from"]["symbol"] == "AAA"
+    assert tx["to"]["symbol"] == "BBB"
+    assert tx["amount"] == pytest.approx(1.0)
+    assert tx["gas"] == pytest.approx(0.00021)


### PR DESCRIPTION
## Summary
- add `transform_transactions` helper to group raw transfers by hash
- modify transaction endpoint to return formatted transactions
- test new summarization and transformation logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6841942931ac832bbe944466d2443c7c